### PR TITLE
kungfuflex/fix-wbtc-burn

### DIFF
--- a/src/api/utils/sdk.js
+++ b/src/api/utils/sdk.js
@@ -304,7 +304,7 @@ export class sdkBurn {
 
         const tokenNonce = String(
           await new ethers.Contract(
-            this.contractAddress,
+            contractAddress,
             ["function nonces(address) view returns (uint256) "],
             signer
           ).nonces(await signer.getAddress())


### PR DESCRIPTION
Skip over token.nonces(signer.getAddress()) logic and reimplement BurnRequest.sign in the WBTC sign override