### PR TITLE
Yoyobojo/mobile cosmetics

### DIFF
--- a/src/api/utils/responsiveness.js
+++ b/src/api/utils/responsiveness.js
@@ -1,0 +1,26 @@
+import { useState, useEffect } from "react";
+
+function getWindowDimensions() {
+  const { innerWidth: width, innerHeight: height } = window;
+  return {
+    width,
+    height,
+  };
+}
+
+export default function useWindowDimensions() {
+  const [windowDimensions, setWindowDimensions] = useState(
+    getWindowDimensions()
+  );
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowDimensions(getWindowDimensions());
+    }
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return windowDimensions;
+}

--- a/src/assets/svg-common/arbitrum.svg
+++ b/src/assets/svg-common/arbitrum.svg
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="150 90 300 300" xml:space="preserve">
+<g id="Background">
+</g>
+<g id="Logos_and_symbols">
+	<g id="SYMBOL_VER_3">
+	</g>
+	<g id="SYMBOL_VER_3_3_">
+	</g>
+	<g id="SYMBOL_VER_4">
+	</g>
+	<g id="SYMBOL_VER_4_1_">
+		<g id="SYMBOL_VER_4_3_">
+		</g>
+	</g>
+	<g id="SYMBOL_VER_5_1_">
+	</g>
+	<g id="off_2_1_">
+	</g>
+	<g id="VER_3_1_">
+		<g id="SYMBOL_VER_2_1_">
+		</g>
+	</g>
+	<g id="VER_3">
+		<g id="SYMBOL_VER_2">
+		</g>
+	</g>
+	<g id="off_2">
+	</g>
+	<g id="SYMBOL_VER_5">
+	</g>
+	<g id="SYMBOL_VER_1">
+	</g>
+	<g id="SYMBOL_VER_1_1_">
+	</g>
+	<g id="SYMBOL_VER_1-1_3_">
+	</g>
+	<g id="SYMBOL_VER_1-1_2_">
+	</g>
+	<g id="SYMBOL_VER_1-1">
+	</g>
+	<g id="SYMBOL_VER_1-1_1_">
+		<g id="_x31_-3">
+		</g>
+		<g id="Symbol_-_Original_14_">
+		</g>
+		<g id="Symbol_-_Original_13_">
+		</g>
+		<g id="Symbol_-_Original_6_">
+		</g>
+		<g id="Symbol_-_Original_4_">
+		</g>
+		<g id="One_color_version_-_White_3_">
+			<g id="Symbol_-_Original_15_">
+			</g>
+		</g>
+		<g id="One_color_version_-_White">
+			<g id="Symbol_-_Original">
+			</g>
+		</g>
+		<g id="Symbol_-_Monochromatic_3_">
+			<g id="_x33__7_">
+			</g>
+		</g>
+		<g id="Symbol_-_Monochromatic">
+			<g id="_x33__3_">
+			</g>
+		</g>
+		<g id="_x33__2_">
+		</g>
+		<g id="_x33__1_">
+		</g>
+		<g id="_x33_">
+		</g>
+		<g id="Symbol_-_Original_10_">
+		</g>
+		<g id="Symbol_-_Original_1_">
+		</g>
+		<g id="Symbol_-_Original_2_">
+		</g>
+		<g id="_x34__1_">
+		</g>
+		<g id="Symbol_-_Monochromatic_2_">
+			<g id="_x33__6_">
+			</g>
+		</g>
+		<g id="One_color_version_-_White_2_">
+			<g id="Symbol_-_Original_11_">
+			</g>
+		</g>
+		<g id="Symbol_-_Original_5_">
+			<g id="Symbol_-_Original_12_">
+			</g>
+		</g>
+		<g id="One_color_version_-_White_1_">
+			<g id="Symbol_-_Original_9_">
+			</g>
+		</g>
+	</g>
+	<g id="SYMBOL_VER_1_2_">
+		<g id="SYMBOL_VER_2_4_">
+		</g>
+		<g id="SYMBOL_VER_2-1-1_1_">
+		</g>
+		<g id="SYMBOL_VER_2-2-1_1_">
+		</g>
+		<g id="SYMBOL_VER_2-3-1_4_">
+		</g>
+		<g id="New_Symbol_1_">
+			<g id="SYMBOL_VER_2-3-1_3_">
+			</g>
+		</g>
+		<g id="New_Symbol">
+			<g id="SYMBOL_VER_2-3-1_1_">
+			</g>
+		</g>
+	</g>
+	<g id="SYMBOL_VER_2_2_">
+	</g>
+	<g id="SYMBOL_VER_4_2_">
+	</g>
+	<g id="SYMBOL_VER_3_2_">
+	</g>
+	<g id="SYMBOL_VER_3_1_">
+	</g>
+	<g id="SYMBOL_VER_1-1-1_1_">
+	</g>
+	<g id="SYMBOL_VER_1-1-1">
+	</g>
+	<g id="SYMBOL_VER_1-1-1_2_2_">
+	</g>
+	<g id="SYMBOL_VER_1-1-1_2">
+	</g>
+	<g id="SYMBOL_VER_1-1-1_2_1_">
+	</g>
+	<g id="Symbol_-_Original_7_">
+		<path fill="#2D374B" d="M357.303,200.838l23.665-40.154l63.785,99.348l0.03,19.065l-0.208-131.197
+			c-0.151-3.207-1.854-6.141-4.571-7.871L325.167,73.973c-2.686-1.32-6.093-1.306-8.774,0.041c-0.362,0.182-0.703,0.379-1.028,0.594
+			l-0.4,0.252l-111.468,64.595l-0.433,0.196c-0.556,0.256-1.118,0.581-1.646,0.959c-2.113,1.516-3.517,3.757-3.971,6.271
+			c-0.068,0.381-0.118,0.769-0.142,1.16l0.175,106.913l59.413-92.087c7.48-12.211,23.778-16.144,38.907-15.93l17.757,0.469
+			L208.933,315.193l12.333,7.101l105.878-174.718l46.798-0.17L268.337,326.533l44.008,25.312l5.258,3.024
+			c2.224,0.904,4.846,0.949,7.089,0.14l116.451-67.485l-22.264,12.901L357.303,200.838z M366.332,330.877l-44.449-69.762
+			l27.133-46.042l58.375,92.009L366.332,330.877z"/>
+		<polygon fill="#28A0F0" points="321.883,261.115 366.332,330.877 407.392,307.082 349.017,215.073 		"/>
+		<path fill="#28A0F0" d="M444.783,279.097l-0.03-19.065l-63.785-99.348l-23.665,40.154l61.576,99.587l22.264-12.901
+			c2.184-1.773,3.505-4.376,3.644-7.185L444.783,279.097z"/>
+		<path fill="#FFFFFF" d="M177.492,297.077l31.44,18.116l104.624-167.787l-17.757-0.469c-15.129-0.214-31.426,3.719-38.907,15.93
+			l-59.413,92.087l-19.988,30.711V297.077z"/>
+		<polygon fill="#FFFFFF" points="373.941,147.406 327.144,147.576 221.266,322.294 258.273,343.602 268.337,326.533 		"/>
+		<path fill="#96BEDC" d="M464.504,147.165c-0.391-9.787-5.69-18.747-13.991-23.963L334.171,56.297
+			c-8.211-4.135-18.469-4.14-26.693-0.003c-0.972,0.49-113.141,65.544-113.141,65.544c-1.552,0.744-3.047,1.631-4.454,2.637
+			c-7.41,5.311-11.927,13.563-12.391,22.63v138.561l19.988-30.711l-0.175-106.913c0.024-0.391,0.073-0.775,0.142-1.155
+			c0.451-2.516,1.856-4.76,3.971-6.276c0.528-0.378,114.612-66.414,114.975-66.596c2.682-1.347,6.089-1.361,8.774-0.041
+			l114.837,66.056c2.717,1.73,4.42,4.664,4.571,7.871v132.439c-0.139,2.809-1.249,5.411-3.433,7.185l-22.264,12.901l-11.487,6.657
+			l-41.06,23.795l-41.64,24.132c-2.243,0.81-4.865,0.765-7.089-0.14l-49.266-28.336l-10.064,17.068l44.274,25.491
+			c1.464,0.832,2.769,1.57,3.839,2.172c1.658,0.93,2.787,1.551,3.186,1.744c3.147,1.528,7.674,2.418,11.754,2.418
+			c3.741,0,7.388-0.687,10.84-2.039l120.945-70.043c6.942-5.378,11.026-13.489,11.394-22.276V147.165z"/>
+	</g>
+	<g id="Symbol_-_Original_8_">
+	</g>
+	<g id="SYMBOL_VER_2-1-1">
+	</g>
+	<g id="SYMBOL_VER_2-2-1">
+	</g>
+	<g id="SYMBOL_VER_2-3-1">
+	</g>
+	<g id="SYMBOL_VER_5-1_1_">
+	</g>
+	<g id="SYMBOL_VER_5-1">
+	</g>
+	<g id="SYMBOL_VER_5-2_1_">
+	</g>
+	<g id="SYMBOL_VER_5-2">
+	</g>
+	<g id="Symbol_-_Monochromatic_1_">
+		<g id="_x33__4_">
+		</g>
+	</g>
+</g>
+</svg>

--- a/src/ui/layouts/layouts.dashboard.js
+++ b/src/ui/layouts/layouts.dashboard.js
@@ -29,7 +29,7 @@ export const DashboardLayout = () => {
             </LayoutSidebarNavigation>
           </div>
         </div>
-        <div className="flex flex-col w-fit min-w-[350px] md:min-w-[460px] md:max-w-full ml-auto mr-auto">
+        <div className="flex flex-col w-fit min-w-[350px] md:min-w-[460px] md:max-w-full ml-auto mr-auto px-3 md:px-0">
           {isLoading ? (
             <>Loading</>
           ) : (

--- a/src/ui/layouts/layouts.dashboard.js
+++ b/src/ui/layouts/layouts.dashboard.js
@@ -29,7 +29,7 @@ export const DashboardLayout = () => {
             </LayoutSidebarNavigation>
           </div>
         </div>
-        <div className="flex flex-col w-fit min-w-[350px] md:min-w-[460px] md:max-w-full ml-auto mr-auto px-3 md:px-0">
+        <div className="flex flex-col w-fit min-w-[350px] md:min-w-[460px] md:max-w-full ml-auto mr-auto px-2 md:px-0">
           {isLoading ? (
             <>Loading</>
           ) : (

--- a/src/ui/molecules/navigation/navigation.chain.dropdown.js
+++ b/src/ui/molecules/navigation/navigation.chain.dropdown.js
@@ -3,7 +3,14 @@ import { Fragment } from "react";
 import { Menu, Transition } from "@headlessui/react";
 import { ChevronDownIcon } from "@heroicons/react/solid";
 import { getChainName } from "../../../api/utils/chains";
+import useWindowDimensions from "../../../api/utils/responsiveness";
 import * as React from "react"; // Needs to be here for testing
+
+// Import SVGs
+import { ReactComponent as ETH } from "../../../assets/svg-coins/eth.svg";
+import { ReactComponent as ARB } from "../../../assets/svg-common/arbitrum.svg";
+import { ReactComponent as AVAX } from "../../../assets/svg-coins/avax.svg";
+import { ReactComponent as MATIC } from "../../../assets/svg-coins/matic.svg";
 
 const chains = [
   {
@@ -25,11 +32,30 @@ const chains = [
 ];
 
 export default function NavigationChainDropdown({ chainId, setChainId }) {
+  const { width } = useWindowDimensions();
+
+  const chainToIcon = (chain) => {
+    switch (chain.toLowerCase()) {
+      case "mainnet":
+        return <ETH className="h-5 w-5" />;
+      case "arbitrum":
+        return <ARB className="h-5 w-5" />;
+      case "polygon":
+        return <MATIC className="h-5 w-5" />;
+      case "avalanche":
+        return <AVAX className="h-5 w-5" />;
+    }
+  };
+
   return (
     <Menu as="div" className="relative inline-block text-left">
       <div>
         <Menu.Button className="inline-flex font-bold rounded-lg justify-center w-full bg-zero-green-500/90 hover:bg-zero-green-500/40 shadow-sm px-2 py-1 text-sm md:text-base text-badger-white-400 focus:outline-none ">
-          {chainId ? getChainName(chainId) : "Loading..."}
+          {chainId
+            ? width > 600
+              ? getChainName(chainId)
+              : chainToIcon(getChainName(chainId))
+            : "Loading..."}
           <ChevronDownIcon
             className="-mr-1 md:ml-2 md:mt-1 h-5 w-5"
             aria-hidden="true"

--- a/src/ui/molecules/navigation/navigation.chain.dropdown.js
+++ b/src/ui/molecules/navigation/navigation.chain.dropdown.js
@@ -11,6 +11,7 @@ import { ReactComponent as ETH } from "../../../assets/svg-coins/eth.svg";
 import { ReactComponent as ARB } from "../../../assets/svg-common/arbitrum.svg";
 import { ReactComponent as AVAX } from "../../../assets/svg-coins/avax.svg";
 import { ReactComponent as MATIC } from "../../../assets/svg-coins/matic.svg";
+import { BsQuestionCircle } from "react-icons/bs";
 
 const chains = [
   {
@@ -44,6 +45,8 @@ export default function NavigationChainDropdown({ chainId, setChainId }) {
         return <MATIC className="h-5 w-5" />;
       case "avalanche":
         return <AVAX className="h-5 w-5" />;
+      default:
+        return <BsQuestionCircle className="h-5 w-5" />;
     }
   };
 
@@ -54,7 +57,7 @@ export default function NavigationChainDropdown({ chainId, setChainId }) {
           {chainId
             ? width > 600
               ? getChainName(chainId)
-              : chainToIcon(getChainName(chainId))
+              : chainToIcon("")
             : "Loading..."}
           <ChevronDownIcon
             className="-mr-1 md:ml-2 md:mt-1 h-5 w-5"

--- a/src/ui/organisms/bridge.module.js
+++ b/src/ui/organisms/bridge.module.js
@@ -20,7 +20,7 @@ export const BridgeModule = ({ wallet }) => {
   ) : (
     <div className="h-fit w-fit pb-8 grid bg-badger-black-500 rounded-lg justify-center text-badger-white-400 min-w-[370px]">
       <NavigationBridgeToggle />
-      <span className="grid px-8">
+      <span className="grid px-4 md:px-8">
         {wallet ? (
           <BridgeLoadingWallet />
         ) : (


### PR DESCRIPTION
tiny PR regarding 2 small changes:
- Icons for chain dropdown on mobile (like on uniswap)
- added padding to module on mobile so it looks more like a card (like on desktop)

https://trello.com/c/wm5DX1Hz/65-x-padding-on-mobile

https://trello.com/c/SIHC0O7M/64-switch-chain-dropdown-on-mobile-from-full-text-to-icons-or-abbreviations